### PR TITLE
Fix comment handling in configuration files

### DIFF
--- a/pycman/config.py
+++ b/pycman/config.py
@@ -95,10 +95,9 @@ def pacman_conf_enumerator(path):
 			filestack.pop()
 			continue
 
+		line = line.split('#')[0]
 		line = line.strip()
 		if len(line) == 0: continue
-		if line[0] == '#':
-			continue
 		if line[0] == '[' and line[-1] == ']':
 			current_section = line[1:-1]
 			continue


### PR DESCRIPTION
**Short explanation:** 
Changed comment parsing in configuration files to properly handle comments within lines like 
`IgnorePkg = ignored-package # irrelevant comment`
instead of only treating lines as comments if they start with `#`.

**Long explanation:**
I was testing out [aurman](https://github.com/polygamma/aurman/) AUR helper and it said that I was ignoring some packages that pacman itself has not been ignoring. Turned out that it used `PacmanConfig` to get info from `/etc/pacman.conf`, which, when parsing the example line provided above, would return `['ignored-package', '#', 'irrelevant', 'comment']` in `PacmanConfig.ignorepkgs`.
pacman itself does the right thing (skips everything after `#`), while this library only skipped lines if they started with `#` and parsed everything else as valid.