### PR TITLE
fix memory leaks

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -308,7 +308,7 @@ PyObject* pyalpm_sync_newversion(PyObject *self, PyObject* args) {
   PyObject *pkg;
   PyObject *dbs;
   alpm_list_t *db_list;
-  alpm_pkg_t *result;
+  alpm_pkg_t *result = NULL;
   if(!PyArg_ParseTuple(args, "OO", &pkg, &dbs)
       || !PyAlpmPkg_Check(pkg)
       || pylist_db_to_alpmlist(dbs, &db_list) == -1)
@@ -319,8 +319,10 @@ PyObject* pyalpm_sync_newversion(PyObject *self, PyObject* args) {
 
   {
     alpm_pkg_t *rawpkg = pmpkg_from_pyalpm_pkg(pkg);
-    if (!rawpkg) return NULL;
-    result = alpm_sync_newversion(rawpkg, db_list);
+    if (rawpkg) {
+      result = alpm_sync_newversion(rawpkg, db_list);
+    }
+    alpm_list_free(db_list);
   }
   if (!result)
     Py_RETURN_NONE;

--- a/src/handle.c
+++ b/src/handle.c
@@ -377,6 +377,16 @@ static PyMethodDef pyalpm_handle_methods[] = {
   {NULL, NULL, 0, NULL},
 };
 
+static void pyalpm_dealloc(PyObject* self) {
+  alpm_handle_t *handle = ALPM_HANDLE(self);
+  int ret = alpm_release(handle);
+  if (ret == -1) {
+    PyErr_Format(alpm_error, "unable to release alpm handle");
+  }
+  handle = NULL;
+  Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
 PyTypeObject AlpmHandleType = {
   PyVarObject_HEAD_INIT(NULL, 0)
   "alpm.Handle",       /*tp_name*/
@@ -387,6 +397,7 @@ PyTypeObject AlpmHandleType = {
   .tp_methods = pyalpm_handle_methods,
   .tp_getset = pyalpm_handle_getset,
   .tp_new = pyalpm_initialize,
+  .tp_dealloc = (destructor) pyalpm_dealloc,
 };
 
 /** Initializes Handle class in module */

--- a/src/pyalpm.c
+++ b/src/pyalpm.c
@@ -100,13 +100,32 @@ static PyMethodDef methods[] = {
   {NULL, NULL, 0, NULL}
 };
 
+static int pyalpm_clear(PyObject *m)
+{
+  PyObject *dict = PyModule_GetDict(m);
+  if (dict == NULL) {
+    return 0;
+  }
+
+  PyObject *error = PyDict_GetItemString(dict, "error");
+  if (error == NULL) {
+    return 0;
+  }
+
+  Py_DECREF(error);
+
+  return 0;
+}
+
 static struct PyModuleDef pyalpm_def = {
   PyModuleDef_HEAD_INIT,
   "alpm",
   "This module wraps the libalpm library",
   -1,
   methods,
-  NULL, NULL, NULL, NULL,
+  NULL, NULL,
+  pyalpm_clear,
+  NULL,
 };
 
 PyMODINIT_FUNC PyInit_pyalpm(void)


### PR DESCRIPTION
The alpm handle is never free'd when it goes out of scope and sync_newversion never free's db_list.