### PR TITLE
Rename alpm sync newversion

### DIFF
--- a/pycman/action_query.py
+++ b/pycman/action_query.py
@@ -48,7 +48,7 @@ def filter_pkglist(pkglist, options):
 			continue
 		if options.foreign and pkg.name in syncpkgs:
 			continue
-		if options.upgrades and pyalpm.sync_newversion(pkg, handle.get_syncdbs()) is None:
+		if options.upgrades and pyalpm.sync_get_new_version(pkg, handle.get_syncdbs()) is None:
 			continue
 		result.append(pkg)
 	return result

--- a/src/db.c
+++ b/src/db.c
@@ -320,7 +320,7 @@ PyObject* pyalpm_sync_newversion(PyObject *self, PyObject* args) {
   {
     alpm_pkg_t *rawpkg = pmpkg_from_pyalpm_pkg(pkg);
     if (rawpkg) {
-      result = alpm_sync_newversion(rawpkg, db_list);
+      result = alpm_sync_get_new_version(rawpkg, db_list);
     }
     alpm_list_free(db_list);
   }

--- a/src/db.c
+++ b/src/db.c
@@ -304,7 +304,7 @@ PyObject* pyalpm_find_grp_pkgs(PyObject* self, PyObject *args) {
 }
 
 /** Finds an available upgrade for a package in a list of databases */
-PyObject* pyalpm_sync_newversion(PyObject *self, PyObject* args) {
+PyObject* pyalpm_sync_get_new_version(PyObject *self, PyObject* args) {
   PyObject *pkg;
   PyObject *dbs;
   alpm_list_t *db_list;
@@ -313,7 +313,7 @@ PyObject* pyalpm_sync_newversion(PyObject *self, PyObject* args) {
       || !PyAlpmPkg_Check(pkg)
       || pylist_db_to_alpmlist(dbs, &db_list) == -1)
   {
-    PyErr_SetString(PyExc_TypeError, "sync_newversion() takes a Package and a list of DBs");
+    PyErr_SetString(PyExc_TypeError, "sync_get_new_version() takes a Package and a list of DBs");
     return NULL;
   }
 

--- a/src/db.h
+++ b/src/db.h
@@ -29,6 +29,6 @@ PyObject *pyalpm_db_from_pmdb(void* data);
 int pylist_db_to_alpmlist(PyObject *list, alpm_list_t **result);
 
 PyObject* pyalpm_find_grp_pkgs(PyObject* self, PyObject* args);
-PyObject* pyalpm_sync_newversion(PyObject *self, PyObject* args);
+PyObject* pyalpm_sync_get_new_version(PyObject *self, PyObject* args);
 
 #endif

--- a/src/pyalpm.c
+++ b/src/pyalpm.c
@@ -87,7 +87,7 @@ static PyMethodDef methods[] = {
     "args: a list of packages, a dependency string\n"
     "returns: a Package object or None" },
 
-  {"sync_newversion", pyalpm_sync_newversion, METH_VARARGS,
+  {"sync_get_new_version", pyalpm_sync_get_new_version, METH_VARARGS,
     "finds an available upgrade for a package in a list of databases\n"
     "args: a package, a list of databases\n"
     "returns: an upgrade candidate or None" },

--- a/test/test_alpm.py
+++ b/test/test_alpm.py
@@ -41,12 +41,12 @@ def test_find_grp_pkgs_error():
         pyalpm.find_grp_pkgs()
     assert 'expected arguments' in str(excinfo.value)
 
-def test_sync_newversion(syncdb, package):
-    assert pyalpm.sync_newversion(package, [syncdb]) is None
+def test_sync_get_new_version(syncdb, package):
+    assert pyalpm.sync_get_new_version(package, [syncdb]) is None
 
-def test_sync_newversion_error():
+def test_sync_get_new_version_error():
     with pytest.raises(TypeError) as excinfo:
-        pyalpm.sync_newversion()
+        pyalpm.sync_get_new_version()
     assert 'takes a Package and a list of DBs' in str(excinfo.value)
 
 # vim: set ts=4 sw=4 et:


### PR DESCRIPTION
`Pacman-git` has updated it's `alpm` API naming scheme.
```
alpm_sync_newversion → alpm_sync_get_new_verison
```
API call should be updated accordingly.
Also, `pyalpm` API could be updated to reflect changes, or preserved to prevent incompatibilities (changes are spit for partisl pull)