### PR TITLE
db: add repr and str to the Database class

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -92,6 +92,20 @@ int pylist_db_to_alpmlist(PyObject *list, alpm_list_t **result) {
   return NULL; \
   }
 
+static PyObject* pyalpm_db_repr(PyObject *rawself) {
+  AlpmDB *self = (AlpmDB *)rawself;
+  return PyUnicode_FromFormat("<alpm.DB(\"%s\") at %p>",
+			      alpm_db_get_name(self->c_data),
+			      self);
+}
+
+static PyObject* pyalpm_db_str(PyObject *rawself) {
+  AlpmDB *self = (AlpmDB *)rawself;
+  return PyUnicode_FromFormat("alpm.DB(\"%s\")",
+			      alpm_db_get_name(self->c_data),
+            self);
+}
+
 /** Database properties */
 
 static PyObject* pyalpm_db_get_name(AlpmDB* self, void* closure) {
@@ -241,6 +255,8 @@ static PyTypeObject AlpmDBType = {
   sizeof(AlpmDB),        /*tp_basicsize*/
   0,                          /*tp_itemsize*/
   .tp_dealloc = (destructor)pyalpm_db_dealloc,
+  .tp_repr = pyalpm_db_repr,
+  .tp_str = pyalpm_db_str,
   .tp_flags = Py_TPFLAGS_DEFAULT,
   .tp_doc = "libalpm DB object",
   .tp_methods = db_methods,

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -65,4 +65,10 @@ def test_db_grpcache_not_empty(syncdb):
     syncdb.update(False)
     assert syncdb.grpcache != []
 
+def test_db_repr(localdb):
+    assert 'local' in repr(localdb)
+
+def test_db_str(localdb):
+    assert 'local' in str(localdb)
+
 # vim: set ts=4 sw=4 et:


### PR DESCRIPTION
Add a repr for the alpm.DB class for interactive usage.