### PR TITLE
src: handle refcounting for Database objects

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -25,7 +25,7 @@
 
 #include <Python.h>
 
-PyObject *pyalpm_db_from_pmdb(void* data);
+PyObject *pyalpm_db_from_pmdb(void* data, PyObject *handle);
 int pylist_db_to_alpmlist(PyObject *list, alpm_list_t **result);
 
 PyObject* pyalpm_find_grp_pkgs(PyObject* self, PyObject* args);

--- a/src/handle.c
+++ b/src/handle.c
@@ -69,13 +69,13 @@ PyObject* pyalpm_initialize(PyTypeObject *subtype, PyObject *args, PyObject *kwa
 
 static PyObject* pyalpm_get_localdb(PyObject *self, PyObject *dummy) {
   alpm_handle_t *handle = ALPM_HANDLE(self);
-  return pyalpm_db_from_pmdb(alpm_get_localdb(handle));
+  return pyalpm_db_from_pmdb(alpm_get_localdb(handle), self);
 }
 
 static PyObject* pyalpm_get_syncdbs(PyObject *self, PyObject *dummy) {
   alpm_handle_t *handle = ALPM_HANDLE(self);
-  return alpmlist_to_pylist(alpm_get_syncdbs(handle),
-			    pyalpm_db_from_pmdb);
+  return alpmlist_to_pylist2(alpm_get_syncdbs(handle),
+			    pyalpm_db_from_pmdb, self);
 }
 
 static PyObject* pyalpm_register_syncdb(PyObject *self, PyObject *args) {
@@ -95,7 +95,7 @@ static PyObject* pyalpm_register_syncdb(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  return pyalpm_db_from_pmdb(result);
+  return pyalpm_db_from_pmdb(result, self);
 }
 
 static PyObject* pyalpm_set_pkgreason(PyObject* self, PyObject* args) {

--- a/src/package.c
+++ b/src/package.c
@@ -249,7 +249,7 @@ static PyObject* pyalpm_package_get_db(AlpmPackage *self, void *closure) {
   CHECK_IF_INITIALIZED();
   db = alpm_pkg_get_db(self->c_data);
   if (db)
-    return pyalpm_db_from_pmdb(db);
+    return pyalpm_db_from_pmdb(db, NULL);
   else
     Py_RETURN_NONE;
 }

--- a/src/package.h
+++ b/src/package.h
@@ -28,6 +28,7 @@
 typedef struct _AlpmPackage {
   PyObject_HEAD
   alpm_pkg_t *c_data;
+  PyObject *db;
   int needs_free;
 } AlpmPackage;
 
@@ -38,7 +39,7 @@ int PyAlpmPkg_Check(PyObject *object);
 
 void pyalpm_pkg_unref(PyObject *object);
 
-PyObject *pyalpm_package_from_pmpkg(void* data);
+PyObject *pyalpm_package_from_pmpkg(void* data, PyObject *db);
 alpm_pkg_t *pmpkg_from_pyalpm_pkg(PyObject *object);
 
 int pylist_pkg_to_alpmlist(PyObject *list, alpm_list_t **result);

--- a/src/pyalpm.c
+++ b/src/pyalpm.c
@@ -59,7 +59,7 @@ static PyObject* pyalpm_find_satisfier(PyObject *self, PyObject* args) {
     Py_RETURN_NONE;
   } else {
     PyObject *result;
-    result = pyalpm_package_from_pmpkg(p);
+    result = pyalpm_package_from_pmpkg(p, NULL);
     if (result == NULL) {
       return NULL;
     } else {

--- a/src/util.c
+++ b/src/util.c
@@ -144,4 +144,29 @@ PyObject* alpmlist_to_pylist(alpm_list_t *prt, PyObject* pybuilder(void*))
   return output;
 }
 
+PyObject* alpmlist_to_pylist2(alpm_list_t *prt, PyObject* pybuilder2(void*, PyObject *self), PyObject *self)
+{
+  /* Check if *self is null to remove this function? */
+  PyObject *output, *stritem;
+  alpm_list_t *tmp;
+
+  output = PyList_New(0);
+  if(output == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "unable to create list object");
+    return NULL;
+  }
+
+  for(tmp = prt; tmp; tmp = alpm_list_next(tmp)) {
+    stritem = pybuilder2(tmp->data, self);
+    if (!stritem) {
+      Py_CLEAR(stritem);
+      return NULL;
+    }
+    PyList_Append(output, stritem);
+    Py_CLEAR(stritem);
+  }
+
+  return output;
+}
+
 /* vim: set ts=2 sw=2 et: */

--- a/src/util.h
+++ b/src/util.h
@@ -48,10 +48,12 @@ void init_pyalpm_error(PyObject* module);
     } while(0)
 
 typedef PyObject *(pyobjectbuilder)(void*);
+typedef PyObject *(pyobjectbuilder2)(void*, PyObject*);
 PyObject* pyobject_from_string(void *s);
 
 /** List conversion functions */
 PyObject* alpmlist_to_pylist(alpm_list_t *prt, pyobjectbuilder pybuilder);
+PyObject* alpmlist_to_pylist2(alpm_list_t *prt, pyobjectbuilder2 pybuilder, PyObject *self);
 int pylist_string_to_alpmlist(PyObject *list, alpm_list_t* *result);
 
 #endif

--- a/test/test_refcounting.py
+++ b/test/test_refcounting.py
@@ -34,6 +34,35 @@ def get_pkg_search():
     return db.search('pacman')[0]
 
 
+def get_pkg_db():
+    db = get_syncdb()
+    db.update(False)
+    return db.get_pkg('pacman')
+
+
+def get_grpcache_pkg():
+    syncdb = get_syncdb()
+    syncdb.update(False)
+    # Returns a tuple
+    return syncdb.grpcache[0][1][0]
+
+
+def get_read_grp():
+    syncdb = get_syncdb()
+    syncdb.update(False)
+    # return pkg
+    return syncdb.read_grp('base-devel')[1][0]
+
+
+def get_db_pkgcache():
+    syncdb = get_syncdb()
+    syncdb.update(False)
+    return syncdb.pkgcache[0]
+
+
+# Database tests, where the Handle goes out of scope
+
+
 def test_localdb_segfault():
     localdb = get_localdb()
     collect()
@@ -51,3 +80,35 @@ def test_register_syncdb_segfault():
     syncdb = register_syncdb()
     collect()
     assert syncdb.search('yay') == []
+
+# Package tests, where the DB goes out of scope
+
+
+def test_pkg_search_segfault():
+    pkg = get_pkg_search()
+    collect()
+    assert pkg.name
+
+
+def test_db_get_pkg_segfault():
+    pkg = get_pkg_db()
+    collect()
+    assert pkg.name
+
+
+def test_db_grpcache_pkg_segfault():
+    pkg = get_grpcache_pkg()
+    collect()
+    assert pkg.name
+
+
+def test_db_read_grp():
+    pkg = get_read_grp()
+    collect()
+    assert pkg.name
+
+
+def test_db_pkgcache():
+    pkg = get_db_pkgcache()
+    collect()
+    assert pkg.name

--- a/test/test_refcounting.py
+++ b/test/test_refcounting.py
@@ -1,0 +1,53 @@
+from gc import collect
+
+from pyalpm import Handle
+from conftest import REPO_1
+
+
+ARCH = 'x86_64'
+TEST_MIRROR = 'https://mirror.pkgbuild.com/{repo}/os/{arch}'
+
+
+def get_localdb():
+    handle = Handle('/', '/tmp/')
+    return handle.get_localdb()
+
+
+def register_syncdb():
+    handle = Handle('/', '/tmp/')
+    repo = handle.register_syncdb(REPO_1, 0)
+    repo.servers = [TEST_MIRROR.format(repo=REPO_1, arch=ARCH)]
+    return repo
+
+
+def get_syncdb():
+    # Return syncdb, so handle should go out of scope
+    handle = Handle('/', '/tmp/')
+    repo = handle.register_syncdb(REPO_1, 0)
+    repo.servers = [TEST_MIRROR.format(repo=REPO_1, arch=ARCH)]
+    return handle.get_syncdbs()[0]
+
+
+def get_pkg_search():
+    db = get_syncdb()
+    db.update(False)
+    return db.search('pacman')[0]
+
+
+def test_localdb_segfault():
+    localdb = get_localdb()
+    collect()
+    x = localdb.search('yay')
+    assert x == []
+
+
+def test_syncdb_segfault():
+    syncdb = get_syncdb()
+    collect()
+    assert syncdb.search('yay') == []
+
+
+def test_register_syncdb_segfault():
+    syncdb = register_syncdb()
+    collect()
+    assert syncdb.search('yay') == []


### PR DESCRIPTION
The current pyalpm implementation does not handle proper refcounting
which means the alpm_handle was never freed otherwise accessing an
object when the Handle goes out of scope leads to segfaults.

This means everything needs to keep a reference to the pyalpm Handle
object for every object created from it. The database object now
receives a Handle and increases the refcount for it to stop it from
being removed by the Python garbage collector.

Signed-off-by: Jelle van der Waa <jelle@archlinux.org>