### PR TITLE
fix documentation of Package.compute_requiredby()

### DIFF
--- a/doc/pyalpm/Package.rst
+++ b/doc/pyalpm/Package.rst
@@ -105,6 +105,6 @@ Packages
 
    .. py:method:: compute_requiredby()
 
-      Computes a list of the packages required by this package
+      Computes a list of the packages this package is required by
 
-     :returns: the packages required by this package
+     :returns: the packages who require this package


### PR DESCRIPTION
The documentation of `Package.compute_requiredby()` incorrectly claims this function returns "a list of the packages required by this package".

This is incorrect. A list of packages required by this package is found in `Package.depends`. This function returns *a list of packages who require this package*.

This PR fixes this oversight.