### PR TITLE
add Package.compute_optionalfor() method

### DIFF
--- a/doc/pyalpm/Package.rst
+++ b/doc/pyalpm/Package.rst
@@ -108,3 +108,9 @@ Packages
       Computes a list of the packages this package is required by
 
      :returns: the packages who require this package
+
+   .. py:method:: compute_optionalfor()
+
+      Computes a list of the packages optionally requiring this package
+
+     :returns: the packages who optionally require this package

--- a/pycman/pkginfo.py
+++ b/pycman/pkginfo.py
@@ -95,6 +95,7 @@ def display_pkginfo(pkg, level=1, style='local'):
 	print(format_attr_oneperline('Optional Deps', pkg.optdepends))
 	if style == 'local' or level == 2:
 		print(format_attr('Required By', pkg.compute_requiredby()))
+		print(format_attr('Optional For', pkg.compute_optionalfor()))
 	print(format_attr('Conflicts With', pkg.conflicts))
 	print(format_attr('Replaces', pkg.replaces))
 	if style == 'sync':

--- a/src/package.c
+++ b/src/package.c
@@ -276,6 +276,18 @@ static PyObject* pyalpm_pkg_compute_requiredby(PyObject *rawself, PyObject *args
   return pyresult;
 }
 
+static PyObject* pyalpm_pkg_compute_optionalfor(PyObject *rawself, PyObject *args) {
+  AlpmPackage *self = (AlpmPackage*)rawself;
+  PyObject *pyresult;
+  CHECK_IF_INITIALIZED();
+  {
+    alpm_list_t *result = alpm_pkg_compute_optionalfor(self->c_data);
+    pyresult = alpmlist_to_pylist(result, pyobject_from_string);
+    FREELIST(result);
+  }
+  return pyresult;
+}
+
 struct list_getter get_licenses = { alpm_pkg_get_licenses, pyobject_from_string };
 struct list_getter get_groups   = { alpm_pkg_get_groups, pyobject_from_string };
 struct list_getter get_backup   = { alpm_pkg_get_backup, pyobject_from_alpm_backup };
@@ -328,6 +340,8 @@ static struct PyGetSetDef AlpmPackageGetSet[] = {
 static struct PyMethodDef pyalpm_pkg_methods[] = {
   { "compute_requiredby", pyalpm_pkg_compute_requiredby, METH_NOARGS,
       "computes the list of packages requiring this package" },
+  { "compute_optionalfor", pyalpm_pkg_compute_optionalfor, METH_NOARGS,
+      "computes the list of packages optionally requiring this package" },
   { NULL }
 };
 

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -48,6 +48,9 @@ def test_download_size(package):
 def test_compute_requiredby(package):
     assert package.compute_requiredby() == ['base']
 
+def test_compute_optionalfor(package):
+    assert package.compute_optionalfor() == []
+
 def test_repr(package):
     assert repr(Package) == "<class 'alpm.Package'>"
     assert PKG in repr(package)


### PR DESCRIPTION
This PR adds the `Package.compute_optionalfor()` method, corresponding to the `alpm_pkg_compute_optionalfor` libalpm method.

This also adds the `Optional For:` block to pycman, to mirror the output pacman gives.