### PR TITLE
fix SystemError when passing arguments to init_transaction

### DIFF
--- a/src/transaction.c
+++ b/src/transaction.c
@@ -284,7 +284,7 @@ PyObject* pyalpm_trans_init(PyObject *self, PyObject *args, PyObject *kwargs) {
 
   /* check all arguments */
   if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-        "|bbbbbbbbbbbbbbbbOOO", (char**)keywords,
+        "|bbbbbbbbbbbbbbbb", (char**)keywords,
         INDEX_FLAGS(&flags))) {
     return NULL;
   }


### PR DESCRIPTION
```pycon
>>> h.init_transaction(cascade=True, nolock=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: more argument specifiers than keyword list entries (remaining format:'OOO')
```