### PR TITLE
Fix Package.size property description

### DIFF
--- a/doc/pyalpm/Package.rst
+++ b/doc/pyalpm/Package.rst
@@ -17,7 +17,7 @@ Packages
 
    .. py:attribute:: size (Long Long)
       
-      A list of references to the packages in this database
+      The archive size
 
    .. py:attribute:: isize (Long Long)
 


### PR DESCRIPTION
Fix small copy-paste mistake in docs for `Package.size` property