### PR TITLE
Simplify and make build process more robust

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,5 @@ scripts =
     scripts/pycman-sync
     scripts/pycman-upgrade
     scripts/pycman-version
+setup_requires =
+    pkgconfig

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = pyalpm
+description = libalpm bindings for Python 3
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Rémy Oudompheng
+author_email = remy@archlinux.org
+classifiers=
+    Development Status :: 6 - Mature
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Programming Language :: C
+    Programming Language :: Python :: 3 :: Only
+    Topic :: System :: Archiving :: Packaging
+    Topic :: System :: Software Distribution
+    Topic :: System :: Systems Administration
+keywords = archlinux, pacman
+license = GPLv3+
+url = https://git.archlinux.org/pyalpm.git/about/
+
+[options]
+packages = pycman
+scripts =
+    scripts/lsoptdepends
+    scripts/pycman-database
+    scripts/pycman-deptest
+    scripts/pycman-query
+    scripts/pycman-remove
+    scripts/pycman-sync
+    scripts/pycman-upgrade
+    scripts/pycman-version

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
           ext_modules=[alpm],
           classifiers=[
               'Development Status :: 6 - Mature',
-              'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+              'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
               'Programming Language :: C',
               'Topic :: System :: Software Distribution',
               'Topic :: System :: Systems Administration',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
               'Development Status :: 6 - Mature',
               'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
               'Programming Language :: C',
+              'Programming Language :: Python :: 3 :: Only',
               'Topic :: System :: Software Distribution',
               'Topic :: System :: Systems Administration',
           ])

--- a/setup.py
+++ b/setup.py
@@ -7,30 +7,29 @@ os.putenv('LC_CTYPE', 'en_US.UTF-8')
 
 pyalpm_version = '0.9.2'
 
+cflags = ['-Wall', '-Wextra', '-Werror',
+          '-Wno-unused-parameter', '-Wno-incompatible-pointer-types',
+          '-Wno-cast-function-type', '-std=c99', '-D_FILE_OFFSET_BITS=64']
+
+alpm = Extension('pyalpm',
+                 libraries=['alpm'],
+                 extra_compile_args=cflags + ['-DVERSION="%s"' % pyalpm_version],
+                 language='C',
+                 sources=['src/pyalpm.c',
+                          'src/util.c',
+                          'src/package.c',
+                          'src/db.c',
+                          'src/options.c',
+                          'src/handle.c',
+                          'src/transaction.c'],
+                 depends=['src/handle.h',
+                          'src/db.h',
+                          'src/options.h',
+                          'src/package.h',
+                          'src/pyalpm.h',
+                          'src/util.h'])
+
 if __name__ == "__main__":
-
-    cflags = ['-Wall', '-Wextra', '-Werror',
-              '-Wno-unused-parameter', '-Wno-incompatible-pointer-types',
-              '-Wno-cast-function-type', '-std=c99', '-D_FILE_OFFSET_BITS=64']
-
-    alpm = Extension('pyalpm',
-                     libraries=['alpm'],
-                     extra_compile_args=cflags + ['-DVERSION="%s"' % pyalpm_version],
-                     language='C',
-                     sources=['src/pyalpm.c',
-                              'src/util.c',
-                              'src/package.c',
-                              'src/db.c',
-                              'src/options.c',
-                              'src/handle.c',
-                              'src/transaction.c'],
-                     depends=['src/handle.h',
-                              'src/db.h',
-                              'src/options.h',
-                              'src/package.h',
-                              'src/pyalpm.h',
-                              'src/util.h'])
-
     setup(version=pyalpm_version,
           ext_modules=[alpm])
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@
 import os
 from setuptools import setup, Extension
 
+import pkgconfig
+libalpm = pkgconfig.parse('libalpm')
 
 os.putenv('LC_CTYPE', 'en_US.UTF-8')
 
@@ -12,7 +14,7 @@ cflags = ['-Wall', '-Wextra', '-Werror',
           '-Wno-cast-function-type', '-std=c99', '-D_FILE_OFFSET_BITS=64']
 
 alpm = Extension('pyalpm',
-                 libraries=['alpm'],
+                 **libalpm,
                  extra_compile_args=cflags + ['-DVERSION="%s"' % pyalpm_version],
                  language='C',
                  sources=['src/pyalpm.c',

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ os.putenv('LC_CTYPE', 'en_US.UTF-8')
 
 pyalpm_version = '0.9.2'
 
-PYCMAN_SCRIPTS = ['database', 'deptest', 'query', 'remove', 'sync', 'upgrade', 'version']
-
 if __name__ == "__main__":
 
     cflags = ['-Wall', '-Wextra', '-Werror',
@@ -33,28 +31,7 @@ if __name__ == "__main__":
                               'src/pyalpm.h',
                               'src/util.h'])
 
-    with open("README.md", "r") as fh:
-        long_description = fh.read()
-
-    setup(name='pyalpm',
-          version=pyalpm_version,
-          description='libalpm bindings for Python 3',
-          long_description=long_description,
-          long_description_content_type="text/markdown",
-          author="Rémy Oudompheng",
-          author_email="remy@archlinux.org",
-          url="https://projects.archlinux.org/pyalpm.git",
-          packages=["pycman"],
-          scripts=["scripts/lsoptdepends"] + [f'scripts/pycman-{p}' for p in PYCMAN_SCRIPTS],
-          ext_modules=[alpm],
-          classifiers=[
-              'Development Status :: 6 - Mature',
-              'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-              'Programming Language :: C',
-              'Programming Language :: Python :: 3 :: Only',
-              'Topic :: System :: Archiving :: Packaging',
-              'Topic :: System :: Software Distribution',
-              'Topic :: System :: Systems Administration',
-          ])
+    setup(version=pyalpm_version,
+          ext_modules=[alpm])
 
 # vim: set ts=4 sw=4 et tw=0:

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
               'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
               'Programming Language :: C',
               'Programming Language :: Python :: 3 :: Only',
+              'Topic :: System :: Archiving :: Packaging',
               'Topic :: System :: Software Distribution',
               'Topic :: System :: Systems Administration',
           ])


### PR DESCRIPTION
There are two basic changes:
- move declarative information about the package into [setup.cfg](https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html)
- Use pkg-config to get information about libalpm rather than hardcoding `-lalpm` and assuming that is enough.

Plus misc cleanup along the way.